### PR TITLE
Accept agent-review trigger without slash

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -31,7 +31,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.issue.pull_request != null &&
-        startsWith(github.event.comment.body, '/agent-review')
+        (
+          startsWith(github.event.comment.body, '/agent-review') ||
+          startsWith(github.event.comment.body, 'agent-review')
+        )
       )
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- allow PR comments starting with either `/agent-review` or `agent-review`
- prevents the workflow job from being skipped when the slash is omitted

## Test
- Expression-only workflow change; no code tests run.