### PR TITLE
Fix sso.php: use correct id column instead of nonexistent SN on user …

### DIFF
--- a/sso.php
+++ b/sso.php
@@ -6,7 +6,7 @@ include '_dbconnect.php';
 if (isset($_GET['username'])) {
     $username = trim($_GET['username']);
 
-    $sql = "SELECT SN, username, Role, user_enrollment, as_duplicate_payment_access 
+    $sql = "SELECT id, username, Role, user_enrollment, as_duplicate_payment_access 
             FROM user WHERE username = ?";
     $stmt = mysqli_prepare($conn, $sql);
     mysqli_stmt_bind_param($stmt, "s", $username);
@@ -14,7 +14,7 @@ if (isset($_GET['username'])) {
     $result = mysqli_stmt_get_result($stmt);
 
     if ($row = mysqli_fetch_assoc($result)) {
-        $userId = $row['SN'];
+        $userId = $row['id'];
         $role = $row['Role'];
         $ip = $_SERVER['REMOTE_ADDR'] ?? 'UNKNOWN';
         $agent = $_SERVER['HTTP_USER_AGENT'] ?? 'UNKNOWN';


### PR DESCRIPTION
…table

The user table's primary key column is id, not SN. This was causing a mysqli_sql_exception (Unknown column SN in field list) whenever the SimpleSAMLphp SSO flow redirected back to sso.php after a successful Auth0 login.


Claude-Session: https://claude.ai/code/session_01NuC8dZYNCYfF3NFYGxD2VH